### PR TITLE
fix fopen() overwriting stdin file handle

### DIFF
--- a/examples/helloworld.c
+++ b/examples/helloworld.c
@@ -3,8 +3,8 @@
 #include <inline/exec.h>
 #include <inline/dos.h>
 
-int __nocommandline=1; /* Disable commandline parsing  */
-int __initlibraries=0; /* Disable auto-library-opening */
+void __nocommandline(){}; /* Disable commandline parsing  */
+void __initlibraries(){}; /* Disable auto-library-opening */
 
 struct DosLibrary *DOSBase=NULL;
 

--- a/sources/Makefile.in
+++ b/sources/Makefile.in
@@ -26,7 +26,7 @@ CURDIR = $(shell pwd)
 
 MAKELIST=$(MAKE) -f $(CURDIR)/Makefile
 
-SUBDIRS=nixmain nix_main misc math nix nix13 nix20 socket stack stubs
+SUBDIRS=misc nixmain nix_main math nix nix13 nix20 socket stack stubs
 
 all: $(foreach f,$(SUBDIRS),$(CURDIR)/$(f))
 	for subdir in $(SUBDIRS); do \

--- a/sources/math/Makefile.in
+++ b/sources/math/Makefile.in
@@ -63,7 +63,7 @@ libm.a: $(foreach f,$(SUBDIRS2),$(CURDIR)/$(f)) $(OBJECTS2) ../../sources/math/M
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS2)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@
 
 stdio/vfprintf.o: $(srcdir)/../nix/stdio/vfprintf.c
 	$(CC) $(OPTIONS) $^ -c -o stdio/vfprintf.o

--- a/sources/misc/Makefile.in
+++ b/sources/misc/Makefile.in
@@ -34,7 +34,7 @@ REDEF=-D_DOSBase=___DOSBase \
 	$(CC) $(OPTIONS) $*2.S -c -o $*.o
 	-rm $*.S $*2.S
 	-if test ! -s $*.err; then rm $*.err; fi
-	echo "\$$$(V)" >>$*.o
+#	echo "\$$$(V)" >>$*.o
 
 .PHONY: all filelist subdirs clean veryclean
 

--- a/sources/nix/Makefile.in
+++ b/sources/nix/Makefile.in
@@ -53,4 +53,4 @@ libnix.a: $(foreach f,$(SUBDIRS),$(CURDIR)/$(f)) $(OBJECTS) ../../sources/nix/Ma
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/nix/stdio/fopen.c
+++ b/sources/nix/stdio/fopen.c
@@ -19,6 +19,7 @@ FILE *fopen(const char *filename,const char *mode)
   { if((node->FILE.buffer=(char *)malloc(BUFSIZ))!=NULL)
     { node->FILE.bufsize=BUFSIZ;
       node->FILE.flags|=__SMBF; /* Buffer is malloc'ed */
+      node->FILE.file = -1;
       if(freopen(filename,mode,&node->FILE)!=NULL)
       { AddHead((struct List *)&__filelist,(struct Node *)&node->node);
         return &node->FILE; }

--- a/sources/nix/stdio/freopen.c
+++ b/sources/nix/stdio/freopen.c
@@ -11,7 +11,8 @@ extern void __seterrno(void);
 FILE *freopen(const char *filename,const char *mode,FILE *stream)
 { int error=__fflush(stream);
 
-  close(stream->file);
+  if (stream->file >= 0)
+    close(stream->file);
   if(stream->name!=NULL) /* file is temporary */
   { BPTR cd=CurrentDir(stream->tmpdir); /* cd t: */
     if(!DeleteFile(stream->name))  /* delete file */

--- a/sources/nix/stdio/open.c
+++ b/sources/nix/stdio/open.c
@@ -40,7 +40,7 @@ static __inline StdFileDes *_allocfd(void)
   int file,max;
 
   for(sfd=stdfiledes,max=stdfilesize,file=0;file<max;sfd++,file++)
-    if(!sfd[0] || !sfd[0]->lx_inuse)
+    if(!sfd[0] || (!sfd[0]->lx_inuse && !sfd[0]->lx_sys))
       break;
 
   if(file>SHRT_MAX)

--- a/sources/nix13/Makefile.in
+++ b/sources/nix13/Makefile.in
@@ -53,4 +53,4 @@ libnix13.a: $(foreach f,$(SUBDIRS),$(CURDIR)/$(f)) $(OBJECTS) ../../sources/nix1
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/nix13/Makefile.in
+++ b/sources/nix13/Makefile.in
@@ -49,6 +49,9 @@ veryclean:
 $(foreach f,$(SUBDIRS),$(CURDIR)/$(f)):
 	mkdir $@
 
+# hack to add swapstack.o into libnix13.a:
+OBJECTS += ../misc/swapstack.o
+
 libnix13.a: $(foreach f,$(SUBDIRS),$(CURDIR)/$(f)) $(OBJECTS) ../../sources/nix13/Makefile ../../sources/nix13/filelist
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)

--- a/sources/nix20/Makefile.in
+++ b/sources/nix20/Makefile.in
@@ -49,6 +49,9 @@ veryclean:
 $(foreach f,$(SUBDIRS),$(CURDIR)/$(f)):
 	mkdir $@
 
+# hack to add swapstack.o into libnix20.a:
+OBJECTS += ../misc/swapstack.o
+
 libnix20.a: $(foreach f,$(SUBDIRS),$(CURDIR)/$(f)) $(OBJECTS) ../../sources/nix20/Makefile ../../sources/nix20/filelist
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)

--- a/sources/nix20/Makefile.in
+++ b/sources/nix20/Makefile.in
@@ -53,4 +53,4 @@ libnix20.a: $(foreach f,$(SUBDIRS),$(CURDIR)/$(f)) $(OBJECTS) ../../sources/nix2
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/nix_main/Makefile.in
+++ b/sources/nix_main/Makefile.in
@@ -51,4 +51,4 @@ libnix_main.a: $(OBJECTS) ../../sources/nix_main/Makefile
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/nixmain/Makefile.in
+++ b/sources/nixmain/Makefile.in
@@ -51,4 +51,4 @@ libnixmain.a: $(OBJECTS) ../../sources/nixmain/Makefile
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/socket/Makefile.in
+++ b/sources/socket/Makefile.in
@@ -71,4 +71,4 @@ libsocket.a: $(foreach f,$(SUBDIRS2),$(CURDIR)/$(f)) $(OBJECTS2) ../../sources/s
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS2)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/stack/Makefile.in
+++ b/sources/stack/Makefile.in
@@ -42,4 +42,4 @@ libstack.a: $(OBJECTS) ../../sources/stack/Makefile ../../sources/stack/filelist
 	-rm -f $@
 	$(AR) -q $@ $(OBJECTS)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/stack/stkrst.c
+++ b/sources/stack/stkrst.c
@@ -19,14 +19,14 @@ asm(
 	"| Race condition ahead! exec might preempt our task at any time storing"
 	"| the current register set on top of the free stack. NEVER set a sp higher"
 	"| than the location of important data."
-	"|"
+	"|\n"
 	"	.comm	___used_stack,8;"		/* pointer to used stackframes */
 	                                    /* pointer to unused stackframes */
 	"	.text;"
 	"	.even;"
 	"	.globl	___stkrst;"
 
-	"__stkrst:;"
+	"___stkrst:;"
 	"	exg	d0,a3;"			/* better use an address register*/
 	"	movel	a2,sp@-;"
 	"	moveml	d0/d1/a0/a1/a5/a6,sp@-;"

--- a/sources/startup/Makefile.in
+++ b/sources/startup/Makefile.in
@@ -22,7 +22,7 @@ OPTIONS=-I$(srcdir)/../headers -O -fomit-frame-pointer
 %.o: %.c
 	$(CC) $(OPTIONS) -c $^ 2>&1|tee $*.err
 	-if test ! -s $*.err; then rm $*.err; fi
-	echo "\$$$(V)" >>$@
+#	echo "\$$$(V)" >>$@
 
 .PHONY: all filelist subdirs clean veryclean
 
@@ -38,31 +38,27 @@ veryclean:
 	-rm *.o
 
 # baserelative resident startup-code
-
 nrcrt0.o: nrcrt0.S
 	$(CC) -c $^
-	echo "\$$$(V)" >>$@
+#	echo "\$$$(V)" >>$@
 
 # large baserelative resident startup-code
-
 nlrcrt0.o: nlrcrt0.S
 	$(CC) -m68020 -c $^
-	echo "\$$$(V)" >>$@
-# baserelative startup code
+#	echo "\$$$(V)" >>$@
 
+# baserelative startup code
 nbcrt0.o: nbcrt0.S
 	$(CC) -c $^
-	echo "\$$$(V)" >>$@
+#	echo "\$$$(V)" >>$@
 
 # large baserelative startup code
-
 nlbcrt0.o: nlbcrt0.S
 	$(CC) -m68020 -c $^
-	echo "\$$$(V)" >>$@
+#	echo "\$$$(V)" >>$@
 
 
 # normal (=large) startup code
-
 ncrt0.o: ncrt0.S
 	$(CC) -c $^
-	echo "\$$$(V)" >>$@
+#	echo "\$$$(V)" >>$@

--- a/sources/stubs/Makefile.in
+++ b/sources/stubs/Makefile.in
@@ -46,4 +46,4 @@ libstubs.a: $(foreach f,$(SUBDIRS2),$(CURDIR)/$(f)) $(OBJECTS2) ../../sources/st
 	rm -f $@
 	$(AR) -q $@ $(OBJECTS2)
 	$(RANLIB) $@
-	echo "\$$$(V)" >>$@
+#	echo "\\$$$(V)" >>$@

--- a/sources/stubs/misc/__cpucheck.c
+++ b/sources/stubs/misc/__cpucheck.c
@@ -47,6 +47,6 @@ ADD2INIT(__cpucheck,-80); /* Highest priority */
 
 #else
 
-int __cpucheck;
+void __cpucheck(){}
 
 #endif


### PR DESCRIPTION
See https://github.com/adtools/libnix/issues/2
Fix is extracted from the fork by @bebbo, specifically the two following commits:
https://github.com/bebbo/libnix/commit/fa82b7a1aa5ca575d79ff8d4b5c55da24b19f835
https://github.com/bebbo/libnix/commit/95dbee7b50409bad6bae725c8f5eab0c836a2338

Please review and merge if it's OK.